### PR TITLE
fix(#41): reset the local euler anlge to zero after each wall climb

### DIFF
--- a/Assets/Scripts/Player/PlayerParkour.cs
+++ b/Assets/Scripts/Player/PlayerParkour.cs
@@ -122,6 +122,7 @@ public class PlayerParkour : MonoBehaviour
                 isParkour = false;
                 parkourProgress = 0f;
                 rigidbodyRef.isKinematic = false;
+                cameraAnimator.transform.localEulerAngles = Vector3.zero;
             }
         }
     }


### PR DESCRIPTION
Fix that after sufficient times of wall climb, the camera will reverse