### PR TITLE
feat(#80): new Wall run mechanic. only leaving the wall or jump or move the camera over than 90 degree of the running direction will end the wall run

### DIFF
--- a/Assets/Scripts/Player/Move and Parkour/PlayerParkour.cs
+++ b/Assets/Scripts/Player/Move and Parkour/PlayerParkour.cs
@@ -206,7 +206,7 @@ public class PlayerParkour : MonoBehaviour
             {
                 currentNormal = normal;
             }
-            else if (!currentNormal.Equals(normal))
+            else if (currentNormal != normal)
             {
                 isWallRunning = false;
                 isWallRunningLeft = false;

--- a/Assets/Scripts/Player/Move and Parkour/PlayerParkour.cs
+++ b/Assets/Scripts/Player/Move and Parkour/PlayerParkour.cs
@@ -187,6 +187,13 @@ public class PlayerParkour : MonoBehaviour
         isWallRunning = isWallRunningLeft || isWallRunningRight;
         playerMoveControl.isWallRunning = isWallRunningLeft || isWallRunningRight;
 
+        if (isWallRunning)
+        {
+            Vector3 normal = (transform.position - leftWallDetection.currentCollider.ClosestPoint(transform.position))
+                .normalized;
+            print(normal);
+        }
+
         if (!previousIsRunningLeft && isWallRunningLeft)
         {
             SetCameraWallRun(true);
@@ -202,9 +209,27 @@ public class PlayerParkour : MonoBehaviour
 
         if (isWallRunning)
         {
-            rigidbodyRef.velocity = new Vector3(rigidbodyRef.velocity.x,
-                upForce,
-                rigidbodyRef.velocity.z);
+            Vector3 lastVelocity = rigidbodyRef.velocity;
+            Vector3 finalVelocity = new Vector3(lastVelocity.x,
+                0f,
+                lastVelocity.z);
+            float finalSpeed = finalVelocity.magnitude;
+            Vector3 normal = Vector3.zero;
+            if (isWallRunningLeft)
+            {
+                normal = (transform.position - leftWallDetection.currentCollider.ClosestPoint(transform.position))
+                    .normalized;
+            }
+            else if (isWallRunningRight)
+            {
+                normal = (transform.position - rightWallDetection.currentCollider.ClosestPoint(transform.position))
+                    .normalized;
+            }
+
+            Vector3 wallVelocity = Vector3.Dot(finalVelocity, normal) * normal;
+            finalVelocity -= wallVelocity;
+            rigidbodyRef.velocity = finalVelocity.normalized * finalSpeed + upForce * Vector3.up;
+
             upForce -= wallRunUpForceChangeRate * Time.deltaTime;
 
             if (PlayerInputHandler.Instance.GetJumpKeyDown())

--- a/Assets/Scripts/Player/Move and Parkour/PlayerParkour.cs
+++ b/Assets/Scripts/Player/Move and Parkour/PlayerParkour.cs
@@ -293,7 +293,7 @@ public class PlayerParkour : MonoBehaviour
 
         float sign = isLeft ? -1 : 1;
         currentCameraAnimation = StartCoroutine(
-            MoveCameraToPosition(
+            MoveCameraWithRotation(
                 new Vector3(0, 0, 30f * sign)
             ));
     }
@@ -305,6 +305,7 @@ public class PlayerParkour : MonoBehaviour
             StopCoroutine(currentCameraAnimation);
         }
 
+        Vector3 rotation = Vector3.zero - cameraAnimator.transform.localEulerAngles;
         currentCameraAnimation = StartCoroutine(
             MoveCameraToPosition(
                 Vector3.zero
@@ -318,7 +319,7 @@ public class PlayerParkour : MonoBehaviour
         Vector3 start = cameraAnimator.transform.localEulerAngles;
         if (start.z > 180f)
         {
-            start += Vector3.back * 360f;
+            dest += Vector3.forward * 360f;
         }
 
         float progress = 0;
@@ -330,5 +331,19 @@ public class PlayerParkour : MonoBehaviour
         }
 
         cameraAnimator.transform.localEulerAngles = dest;
+    }
+
+    private IEnumerator MoveCameraWithRotation(Vector3 rotation)
+    {
+        float init = Time.time;
+        float duration = cameraAnimationDuration;
+
+        float progress = 0;
+        while (progress < 1f)
+        {
+            progress = (Time.time - init) / duration;
+            cameraAnimator.transform.Rotate(rotation / duration * Time.deltaTime);
+            yield return null;
+        }
     }
 }

--- a/Assets/Scripts/Player/ObstructionDetection.cs
+++ b/Assets/Scripts/Player/ObstructionDetection.cs
@@ -8,7 +8,7 @@ public class ObstructionDetection : MonoBehaviour
     public string targetTagName = "";
     public bool isObstructed;
     public GameObject target;
-    private Collider currentCollider;
+    public Collider currentCollider;
 
     private void OnTriggerStay(Collider other)
     {


### PR DESCRIPTION
- only leaving the wall or jump or move the camera over than 90 degree of the running direction will end the wall run
- the player now works automatically on the wall like ghostrunner
- fix the camera rotation bug under most conditions. but it may still exist
- leaving the bug that sometimes the player will jump very high to the sky